### PR TITLE
Ensure helpers are available during active_association_form calls 

### DIFF
--- a/app/helpers/active_admin_associations_helper.rb
+++ b/app/helpers/active_admin_associations_helper.rb
@@ -21,7 +21,8 @@ module ActiveAdminAssociationsHelper
         f.inputs *active_admin_config.form_columns
       end
       if active_admin_config.active_association_form && active_admin_config.active_association_form.respond_to?(:call)
-        active_admin_config.active_association_form.call(f)
+        form_proc = active_admin_config.active_association_form
+        instance_exec(f, &form_proc)
       end
       f.actions
     end


### PR DESCRIPTION
Using instance execute to run the active_association_form blocks within a context with helper methods exposed. In particular changing this so current_admin_user is available. 
